### PR TITLE
spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ Options exists to output to file, choose pages range etc.
 Usage: TextExtraction.exe filepath <option(s)>
 filepath - pdf file path
 Options:
-        -s, --start <d>                 start text extraction from a page index. use negative numbers to subtract from pages count
-        -e, --end <d>                   end text extraction upto page index. use negative numbers to subtract from pages count
-        -b, --bidi <RTL|LTR>            use bidi algo to convert visual to logical. provide default direction per document writing direction.
-        -o, --output /path/to/file      write result to output file
-        -q, --quiet                     quiet run. only shows errors and warnings
-        -h, --help                      Show this help message
-        -d, --debug /path/to/file       create debug output file
+        -s, --start <d>                         start text extraction from a page index. use negative numbers to subtract from pages count
+        -e, --end <d>                           end text extraction upto page index. use negative numbers to subtract from pages count
+        -b, --bidi <RTL|LTR>                    use bidi algo to convert visual to logical. provide default direction per document writing direction.
+        -p, --spacing <BOTH|HOR|VER|NONE>       add spaces between pieces of text considering their relative positions. default is BOTH.
+        -o, --output /path/to/file              write result to output file
+        -q, --quiet                             quiet run. only shows errors and warnings
+        -h, --help                              Show this help message
+        -d, --debug /path/to/file               create debug output file
 ```
 
 # First time around

--- a/TextExtraction/TextExtraction.h
+++ b/TextExtraction/TextExtraction.h
@@ -9,6 +9,7 @@
 #include "ErrorsAndWarnings.h"
 #include "RefCountPtr.h"
 
+#include <sstream>
 #include <string>
 #include <list>
 
@@ -34,6 +35,15 @@ typedef std::map< RefCountPtr<PDFObject>, FontDecoder,  LessRefCountPDFObject> P
 class TextExtraction {
 
     public:
+
+        enum ESpacing
+        {
+            eSpacingNone = 0,
+            eSpacingHorizontal = 1,
+            eSpacingVertical = 2,
+            eSpacingBoth = 3
+        };
+
         TextExtraction();
         virtual ~TextExtraction();
 
@@ -51,7 +61,7 @@ class TextExtraction {
             const std::string& inTargetOutputFilePath
         );
 
-        std::string GetResultsAsText(int bidiFlag);
+        std::string GetResultsAsText(int bidiFlag, ESpacing spacingFlag);
 
     private:
         // interim work construct
@@ -68,5 +78,12 @@ class TextExtraction {
         PDFHummus::EStatusCode ComputeResultPlacements();
 
         FontDecoder* GetDecoderForCommand(PDFParser* inParser, PlacedTextCommand& inCommand);
-
+        void MergeLineStreamToResultString(    
+            const std::stringstream& inStream, 
+            int bidiFlag,
+            bool shouldAddSpacesPerLines, 
+            const double (&inLineBox)[4],
+            const double (&inPrevLineBox)[4],
+            std::stringstream& refStream
+        );
 };

--- a/TextExtraction/lib/font-translation/FontDecoder.cpp
+++ b/TextExtraction/lib/font-translation/FontDecoder.cpp
@@ -21,6 +21,9 @@
 using namespace std;
 using namespace PDFHummus;
 
+#define SPACE_CODE 32
+#define M_CODE 77
+
 static const Encoding scEncoding;
 static const StandardFontsDimensions scStandardFontsDimensions;
 
@@ -277,7 +280,7 @@ void FontDecoder::ParseCIDFontDimensions(PDFParser* inParser, PDFDictionary* inF
                 PDFArray* asArray = (PDFArray*)it.GetItem();
                 it.MoveNext();
                 
-                SingleValueContainerIterator<PDFObjectVector> itArray = widthsArray->GetIterator();
+                SingleValueContainerIterator<PDFObjectVector> itArray = asArray->GetIterator();
                 unsigned long j=0;
                 while(itArray.MoveNext()) {
                     widths[cFirst + j] = ParsedPrimitiveHelper(itArray.GetItem()).GetAsDouble();
@@ -331,6 +334,8 @@ void FontDecoder::ParseFontData(PDFParser* inParser, PDFDictionary* inFont) {
     else {
         ParseCIDFontDimensions(inParser, inFont);
     }
+    double computedSpaceWidth = GetCodeWidth(SPACE_CODE);
+    spaceWidth = (isMonospaced ? monospaceWidth : (computedSpaceWidth == 0 ?  GetCodeWidth(M_CODE) : computedSpaceWidth))/1000;
 }
 
 string FontDecoder::ToUnicodeEncoding(const ByteList& inAsBytes) {

--- a/TextExtraction/lib/font-translation/FontDecoder.h
+++ b/TextExtraction/lib/font-translation/FontDecoder.h
@@ -39,6 +39,7 @@ public:
 
     double ascent;
     double descent;
+    double spaceWidth;
 private:
     bool isSimpleFont;
     bool hasToUnicode;

--- a/TextExtraction/lib/text-placements/TextPlacement.h
+++ b/TextExtraction/lib/text-placements/TextPlacement.h
@@ -109,6 +109,7 @@ struct PlacedTextCommand {
 
     // Provided by third phase, of dimensions computation
     double localBBox[4];
+    double spaceWidth;
 };
 
 typedef std::list<PlacedTextCommand> PlacedTextCommandList;
@@ -128,18 +129,21 @@ struct ResultTextCommand {
         const std::string& inText,
         const double (&inMatrix)[6],
         const double (&inLocalBox)[4],
-        const double (&inGlobalBox)[4]
+        const double (&inGlobalBox)[4],
+        const double inSpaceWidth
     ) {
         text = inText;
         copyMatrix(inMatrix, matrix);
         copyBox(inLocalBox, localBbox);
         copyBox(inGlobalBox, globalBbox);
+        spaceWidth = inSpaceWidth;
     }
 
     std::string text;
     double matrix[6];
     double localBbox[4];
     double globalBbox[4];
+    double spaceWidth;
 };
 
 

--- a/TextExtractionTesting/CMakeLists.txt
+++ b/TextExtractionTesting/CMakeLists.txt
@@ -13,7 +13,7 @@ set_property (TEST TextExtractionNoInputPrintsUsage PROPERTY PASS_REGULAR_EXPRES
 
 # simple file test
 add_test(NAME TextExtractionSimpleInputPrintsText COMMAND TextExtraction ${CMAKE_CURRENT_SOURCE_DIR}/Materials/HighLevelContentContext.pdf)
-set_property (TEST TextExtractionSimpleInputPrintsText PROPERTY PASS_REGULAR_EXPRESSION "PathsSquares\nCirclesRectangles")
+set_property (TEST TextExtractionSimpleInputPrintsText PROPERTY PASS_REGULAR_EXPRESSION "Paths[ \t\r\n]*Squares[ \\t\r\n]*Circles[ \t\r\n]*Rectangles")
 
 # my cv test
 add_test(NAME TextExtractionCVInputPrintsText COMMAND TextExtraction ${CMAKE_CURRENT_SOURCE_DIR}/Materials/GalKahanaCV2022.pdf)


### PR DESCRIPTION
As a prep for a possible future table extraction feature i was trying to see if i can get this code better at implementing spacing. both horizontal and vertical.

the current algorithm (before those changes) doesn't really consider spacing between the texts before concatenating them. so if texts in the same row dont have a literal space "glyph" between them but are instead spaced using placement that puts that at distance from each other...this algo will probably think it's the same word and wont have space between them.
Also there's no vertical spacing. lines are just placed one after the other without considering the vertical spacing between them. a better algorithm will make it easy to figure out one paragraph from another.


So - this PR. This PR checks spacing between text placements and lines and based on the font the line/text is in determine how many spaces match the distance between those text placements. i reckon the results are not too bad per what i'm seeing in the testing.

while implementing this i discovered a severe bug in the existing code where CID width reading is totally wrong. I had a bug there all this time. As a result good chances are that any text in a CID font got something like 0 width or any other irrelevant width. anyways...sorted this out.

didn't do initial indentation. i mean texts can be indented in the line and one can add spaces in the beginning of the line (adhering to BIDI text), but i left this for another time and stuck to spacing between lines and between words in a line.

The option to add spaces is open by default, but can be shut down (or you can select vertical/horizontal) by providing a relevant CLI argument (see readme/cli help).
