### PR TITLE
feat: add methods in libary to accept custom stream. either as parser or custom stream

### DIFF
--- a/TextExtraction/TableExtraction.h
+++ b/TextExtraction/TableExtraction.h
@@ -16,6 +16,7 @@
 #include "ErrorsAndWarnings.h"
 
 class PDFParser;
+class IByteReaderWithPosition;
 
 #include <sstream>
 #include <string>
@@ -33,6 +34,8 @@ class TableExtraction : public ITextInterpreterHandler, IGraphicContentInterpret
         virtual ~TableExtraction();
 
         PDFHummus::EStatusCode ExtractTables(const std::string& inFilePath, long inStartPage=0, long inEndPage=-1);
+        PDFHummus::EStatusCode ExtractTables(PDFParser* inParser, long inStartPage=0, long inEndPage=-1);
+        PDFHummus::EStatusCode ExtractTables(IByteReaderWithPosition* inStream, long inStartPage=0, long inEndPage=-1);
 
         ExtractionError LatestError;
         ExtractionWarningList LatestWarnings;  
@@ -65,5 +68,6 @@ class TableExtraction : public ITextInterpreterHandler, IGraphicContentInterpret
 
         PDFHummus::EStatusCode ExtractTablePlacements(PDFParser* inParser, long inStartPage, long inEndPage);
         void ComposeTables();
+        void ClearState();
         
 };

--- a/TextExtraction/TextExtraction.h
+++ b/TextExtraction/TextExtraction.h
@@ -11,6 +11,7 @@
 #include "ErrorsAndWarnings.h"
 
 class PDFParser;
+class IByteReaderWithPosition;
 
 #include <sstream>
 #include <string>
@@ -27,6 +28,8 @@ class TextExtraction : public ITextInterpreterHandler, IGraphicContentInterprete
         virtual ~TextExtraction();
 
         PDFHummus::EStatusCode ExtractText(const std::string& inFilePath, long inStartPage=0, long inEndPage=-1);
+        PDFHummus::EStatusCode ExtractText(PDFParser* inParser, long inStartPage=0, long inEndPage=-1);
+        PDFHummus::EStatusCode ExtractText(IByteReaderWithPosition* inStream, long inStartPage=0, long inEndPage=-1);
 
         ExtractionError LatestError;
         ExtractionWarningList LatestWarnings;  
@@ -55,4 +58,5 @@ class TextExtraction : public ITextInterpreterHandler, IGraphicContentInterprete
         double currentPageScopeBox[4];
 
         PDFHummus::EStatusCode ExtractTextPlacements(PDFParser* inParser, long inStartPage, long inEndPage);
+        void ClearState();
 };


### PR DESCRIPTION
minor enhancement to library usage.
allowing to provide both TableExtraction and TextExtraction with non files.
in both i added overrides for the base function with either one of:
- `IByteReaderWithPosition*` inStream
- `PDFParser* inParser

The first option gets an input of a stream, starts parser on it, and moves to parsing text. this is good for anyone who doesn't want to commit to a file, but say a pdf in mem, for example.

Allowing to provide a PDFParser, as an alternative, provides both the option of using a custom input stream, like the first option, but also be able to use the PDFParser for other things, like grabbing some metadata, check if the pdf is password protected (and whether a good password was provided) etc.

