### PR TITLE
updated to 4.8 improvement of bytelist, and reuse the definition from there

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ option(SHOULD_PARSE_INTERNAL_TABLES  "should table parsing read internal tables"
 include(FetchContent)
 FetchContent_Declare(
   PDFHummus
-  URL https://github.com/galkahana/PDF-Writer/archive/refs/tags/v4.7.0.tar.gz
-  URL_HASH SHA256=936c1ed887c5fd23da8cd9ff23c1bfa58545f60f66af8ff893024eda5dda1b98
+  URL https://github.com/galkahana/PDF-Writer/archive/refs/tags/v4.8.0.tar.gz
+  URL_HASH SHA256=67809a216025a4046b1662446544b76a47729eb6ba86d0aebb982b945dca8470
   DOWNLOAD_EXTRACT_TIMESTAMP FALSE
   FIND_PACKAGE_ARGS
 )

--- a/TextExtraction/lib/pdf-writer-enhancers/Bytes.cpp
+++ b/TextExtraction/lib/pdf-writer-enhancers/Bytes.cpp
@@ -7,26 +7,20 @@
 using namespace std;
 
 ByteList ToBytesList(PDFObject* inObject) {
-    ByteList result;
-    
     switch(inObject->GetType())
     {
         case PDFObject::ePDFObjectLiteralString: {
-            string str = ((PDFLiteralString*)inObject)->GetValue();
-            for(string::iterator it = str.begin();it != str.end(); ++it)
-                result.push_back((IOBasicTypes::Byte)(*it));
+            return stringToByteList(((PDFLiteralString*)inObject)->GetValue());
             break;
         }
         case PDFObject::ePDFObjectHexString: {
-            string str = ((PDFHexString*)inObject)->GetValue();
-            for(string::iterator it = str.begin();it != str.end(); ++it)
-                result.push_back((IOBasicTypes::Byte)(*it));
+            return stringToByteList(((PDFHexString*)inObject)->GetValue());
             break;
         }
         default: {
             // nothing
+            return ByteList();
         }
     }
 
-    return result;  
 }

--- a/TextExtraction/lib/pdf-writer-enhancers/Bytes.h
+++ b/TextExtraction/lib/pdf-writer-enhancers/Bytes.h
@@ -1,9 +1,5 @@
-#include "IOBasicTypes.h"
+#include "ByteList.h"
 
-#include <list>
-
-typedef std::list<IOBasicTypes::Byte> ByteList;
 class PDFObject;
-
 
 ByteList ToBytesList(PDFObject* inObject);


### PR DESCRIPTION
there was a performance improvement in pdfwriter a while ago with ByteLists. this PR updates to use a new version that has this improvement (https://github.com/galkahana/PDF-Writer/pull/307) and also reuses that structure here.