### PR TITLE
feat: efficient direct output to stream, instead of stream->string->stream

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -72,6 +72,10 @@
         "functional": "cpp",
         "iterator": "cpp",
         "xstring": "cpp",
-        "xtree": "cpp"
+        "xtree": "cpp",
+        "__verbose_abort": "cpp",
+        "print": "cpp",
+        "execution": "cpp",
+        "queue": "cpp"
     }
 }

--- a/TextExtraction/TableExtraction.cpp
+++ b/TextExtraction/TableExtraction.cpp
@@ -195,13 +195,12 @@ void TableExtraction::ComposeTables() {
 
 static const string scCRLN = "\r\n";
 
-string TableExtraction::GetTableAsCSVText(const Table& inTable, int bidiFlag, TextComposer::ESpacing spacingFlag) {
+void TableExtraction::GetTableAsCSVText(const Table& inTable, int bidiFlag, TextComposer::ESpacing spacingFlag, std::ostream& outStream) {
     TableCSVExport exporter(bidiFlag, spacingFlag);
-    exporter.ComposeTableText(inTable);
-    return exporter.GetText();  
+    exporter.ComposeTableText(inTable, outStream);
 }
 
-string TableExtraction::GetAllAsCSVText(int bidiFlag, TextComposer::ESpacing spacingFlag) {
+void TableExtraction::GetAllAsCSVText(int bidiFlag, TextComposer::ESpacing spacingFlag, std::ostream& outStream) {
     TableCSVExport exporter(bidiFlag, spacingFlag);
 
     TableListList::iterator itPages = tablesForPages.begin();
@@ -209,15 +208,13 @@ string TableExtraction::GetAllAsCSVText(int bidiFlag, TextComposer::ESpacing spa
     for(; itPages != tablesForPages.end(); ++itPages) {
         TableList::iterator itTables = itPages->begin();
         for(; itTables != itPages->end(); ++itTables) {
-            exporter.ComposeTableText(*itTables);
-            exporter.AppendText(scCRLN); // two newlines to separate tables on the same page
-            exporter.AppendText(scCRLN);
+            exporter.ComposeTableText(*itTables, outStream);
+            outStream<<scCRLN; // two newlines to separate tables on the same page
+            outStream<<scCRLN;
         }
-        exporter.AppendText(scCRLN); // 4 newlines to separate pages
-        exporter.AppendText(scCRLN);
-        exporter.AppendText(scCRLN);
-        exporter.AppendText(scCRLN);
+        outStream<<scCRLN; // 4 newlines to separate pages
+        outStream<<scCRLN;
+        outStream<<scCRLN;
+        outStream<<scCRLN;
     }
-
-    return exporter.GetText();
 }

--- a/TextExtraction/TableExtraction.h
+++ b/TextExtraction/TableExtraction.h
@@ -54,8 +54,8 @@ class TableExtraction : public ITextInterpreterHandler, IGraphicContentInterpret
         virtual bool OnParsedHorizontalLinePlacementComplete(const ParsedLinePlacement& inParsedLine); 
         virtual bool OnParsedVerticalLinePlacementComplete(const ParsedLinePlacement& inParsedLine); 
 
-        std::string GetTableAsCSVText(const Table& inTable, int bidiFlag, TextComposer::ESpacing spacingFlag);
-        std::string GetAllAsCSVText(int bidiFlag, TextComposer::ESpacing spacingFlag);
+        void GetTableAsCSVText(const Table& inTable, int bidiFlag, TextComposer::ESpacing spacingFlag, std::ostream& outStream);
+        void GetAllAsCSVText(int bidiFlag, TextComposer::ESpacing spacingFlag, std::ostream& outStream);
 
     private:
         TextInterpeter textInterpeter;

--- a/TextExtraction/TextExtraction.cpp
+++ b/TextExtraction/TextExtraction.cpp
@@ -153,16 +153,14 @@ PDFHummus::EStatusCode TextExtraction::ExtractText(IByteReaderWithPosition* inSt
 
 static const string scCRLN = "\r\n";
 
-std::string TextExtraction::GetResultsAsText(int bidiFlag, TextComposer::ESpacing spacingFlag) {
+void TextExtraction::GetResultsAsText(int bidiFlag, TextComposer::ESpacing spacingFlag, std::ostream& outStream) {
     ParsedTextPlacementListList::iterator itPages = textsForPages.begin();
     TextComposer composer(bidiFlag, spacingFlag);
 
     for(; itPages != textsForPages.end();++itPages) {
-        composer.ComposeText(*itPages);
-        composer.AppendText(scCRLN);
+        composer.ComposeText(*itPages, outStream);
+        outStream<<scCRLN;
     }
-
-    return composer.GetText();
 }
 
 

--- a/TextExtraction/TextExtraction.h
+++ b/TextExtraction/TextExtraction.h
@@ -43,7 +43,7 @@ class TextExtraction : public ITextInterpreterHandler, IGraphicContentInterprete
             const std::string& inTargetOutputFilePath
         );
 
-        std::string GetResultsAsText(int bidiFlag, TextComposer::ESpacing spacingFlag);
+        void GetResultsAsText(int bidiFlag, TextComposer::ESpacing spacingFlag, std::ostream& outStream);
 
         // IGraphicContentInterpreterHandler implementation
         virtual bool OnTextElementComplete(const TextElement& inTextElement);

--- a/TextExtraction/lib/table-csv-export/TableCSVExport.cpp
+++ b/TextExtraction/lib/table-csv-export/TableCSVExport.cpp
@@ -17,58 +17,46 @@ TableCSVExport::~TableCSVExport() {
 
 }
 
-void TableCSVExport::Quote(const string& inString) {
+void TableCSVExport::Quote(const string& inString, std::ostream& outStream) {
     if(inString.length() == 0) {
-        // don't quote if there's nothing and no need to introduce anything into the buffer
+        // don't quote if there's nothing and no need to introduce anything into the stream
         return;
     }
 
-    buffer<<scDoubleQuote;
+    outStream<<scDoubleQuote;
     string::const_iterator it = inString.begin();
     for(; it != inString.end();++it) {
         if(*it == scDoubleQuoteChar)
-            buffer<<scDoubleQuote<<scDoubleQuote;
+            outStream<<scDoubleQuote<<scDoubleQuote;
         else
-            buffer<<*it;
+            outStream<<*it;
     }
-    buffer<<scDoubleQuote;
+    outStream<<scDoubleQuote;
 }
 
 string TableCSVExport::GetCellText(const CellInRow& inCell) {
-    textComposer.ComposeText(inCell.textPlacements);
-    string cellText = textComposer.GetText();
-    textComposer.Reset();
-
-    return cellText;
+    std::stringstream cellStream;
+    textComposer.ComposeText(inCell.textPlacements, cellStream);
+    return cellStream.str();
 }
 
-void TableCSVExport::ComposeTableText(const Table& inTable) {
+void TableCSVExport::ComposeTableText(const Table& inTable, std::ostream& outStream) {
     RowVector::const_iterator itRows = inTable.rows.begin();
 
     for(; itRows != inTable.rows.end(); ++itRows) {
         CellInRowVector::const_iterator itCols = itRows->cells.begin();
-        Quote(GetCellText(*itCols));
+        Quote(GetCellText(*itCols), outStream);
         ++itCols;
         for(; itCols != itRows->cells.end(); ++itCols) {
-            buffer<<scComma;
-            Quote(GetCellText(*itCols));
+            outStream<<scComma;
+            Quote(GetCellText(*itCols), outStream);
             for(int i = 1; i < itCols->colSpan;++i)
-                buffer<<scComma;
+                outStream<<scComma;
         }
-        buffer<<scCRLN;
+        outStream<<scCRLN;
     }
 }
 
-void TableCSVExport::AppendText(const std::string inText) {
-    buffer<<inText;
-}
 
-std::string TableCSVExport::GetText() {
-    return buffer.str();
-}
-
-void TableCSVExport::Reset() {
-    buffer.str(scEmpty);
-}
 
 

--- a/TextExtraction/lib/table-csv-export/TableCSVExport.h
+++ b/TextExtraction/lib/table-csv-export/TableCSVExport.h
@@ -2,6 +2,7 @@
 
 #include "../text-composition/TextComposer.h"
 #include "../table-composition/Table.h"
+#include <ostream>
 
 class TableCSVExport {
     public:
@@ -9,18 +10,12 @@ class TableCSVExport {
         virtual ~TableCSVExport();
 
 
-        void ComposeTableText(const Table& inTable);
-
-        void AppendText(const std::string inText); // use this for extra chars
-
-        std::string GetText();
-        void Reset();
+        void ComposeTableText(const Table& inTable, std::ostream& outStream);
 
     private:
         TextComposer textComposer;
-        std::stringstream buffer;
 
         std::string GetCellText(const CellInRow& inCell);
-        void Quote(const std::string& inString);
+        void Quote(const std::string& inString, std::ostream& outStream);
 
 };

--- a/TextExtraction/lib/text-composition/TextComposer.h
+++ b/TextExtraction/lib/text-composition/TextComposer.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <list>
 #include <sstream>
+#include <ostream>
 
 class TextComposer {
     public:
@@ -21,24 +22,19 @@ class TextComposer {
         virtual ~TextComposer();
 
 
-        void ComposeText(const ParsedTextPlacementList& inTextPlacements);
-
-        void AppendText(const std::string inText); // use this for extra chars
-
-        std::string GetText();
-        void Reset();
+        void ComposeText(const ParsedTextPlacementList& inTextPlacements, std::ostream& outStream);
 
     private:
         int bidiFlag;
         ESpacing spacingFlag;
-        std::stringstream buffer;
 
     void MergeLineStreamToResultString(
         const std::stringstream& inStream, 
         int bidiFlag,
         bool shouldAddSpacesPerLines, 
         const double (&inLineBox)[4],
-        const double (&inPrevLineBox)[4]
+        const double (&inPrevLineBox)[4],
+        std::ostream& outStream
     );
 
 


### PR DESCRIPTION
There's a current inefficient flow in the app when extracting text or tables and directing to the final output - stdout or file.
the text/table composers dump the text to an internal stream. then the client asks for a string of that stream, which is carried out by converting the stream to a string. then finally that string is written to the output stream - either of stdout or file.

2 inneficiencies:
- no point to write to stream convert to string write it to stream. might as well cut the middleman and write directly to the outcome stream. it does mean we might get partial output if there's an error during the process, instead of getting nothing...but i don't think that's an actual problem.
- memory. now why hold the full text of something as a string only to output it to a stream. we can save allocating more an more memory, and just emit the partial content as it comes. this should be very significant in files with a lot of text.