### PR TITLE
feat: deal with ascent/descent being 0 with fallback and assertion

### DIFF
--- a/TextExtraction/lib/text-composition/TextComposer.cpp
+++ b/TextExtraction/lib/text-composition/TextComposer.cpp
@@ -162,8 +162,8 @@ void TextComposer::MergeLineStreamToResultString(
 ) {
     BidiConversion bidi;
 
-    // add spaces before line, per distance from last line
-    if(shouldAddSpacesPerLines && BoxTop(inLineBox) < BoxBottom(inPrevLineBox)) {
+    // add spaces before line, per distance from last line (verify that we have non zero height to avoid infinite loops)
+    if(shouldAddSpacesPerLines && BoxTop(inLineBox) < BoxBottom(inPrevLineBox) && BoxHeight(inPrevLineBox) > 0) {
         unsigned long verticalLines = floor((BoxBottom(inPrevLineBox) - BoxTop(inLineBox))/BoxHeight(inPrevLineBox));
         for(unsigned long i=0;i<verticalLines;++i)
             outStream<<scCRLN;


### PR DESCRIPTION
when parsing the pdf ref man i saw that on page 24 if get a sort of endless loop.
turns out the vertical spacing code (on by default) does not check for 0 height of previous line, so it can easily get to max int loop count which incorrectly creates huge files.
also, ascent and descent info missing is not super rare, so figured to fallback on font bbox and cap height to attempt to get sort of right dimensions.