### PR TITLE
feat: using PlacedTextCommandArgumentVector instead of PlacedTextCommandArgumentList

### DIFF
--- a/TextExtraction/lib/graphic-content-parsing/GraphicContentInterpreter.cpp
+++ b/TextExtraction/lib/graphic-content-parsing/GraphicContentInterpreter.cpp
@@ -421,12 +421,12 @@ bool GraphicContentInterpreter::TStarCommand() {
 }
 
 void GraphicContentInterpreter::RecordTextPlacement(const PlacedTextCommandArgument& inTextPlacementOperation) {
-    PlacedTextCommandArgumentList placements;
+    PlacedTextCommandArgumentVector placements;
     placements.push_back(inTextPlacementOperation);
     RecordTextPlacement(placements);
 }
 
-void GraphicContentInterpreter::RecordTextPlacement(const PlacedTextCommandArgumentList& inTextPlacementOperations) {
+void GraphicContentInterpreter::RecordTextPlacement(const PlacedTextCommandArgumentVector& inTextPlacementOperations) {
     PlacedTextCommand el = {
         inTextPlacementOperations,
         ContentGraphicState(CurrentGraphicState()),
@@ -470,7 +470,7 @@ bool GraphicContentInterpreter::TJCommand(const PDFObjectVector& inOperands) {
     if(inOperands.size() < 1)
         return true; // too few params? ignore
     
-    PlacedTextCommandArgumentList placements;
+    PlacedTextCommandArgumentVector placements;
     PDFObjectCastPtr<PDFArray> arg;
 
     arg = inOperands.back();

--- a/TextExtraction/lib/graphic-content-parsing/GraphicContentInterpreter.h
+++ b/TextExtraction/lib/graphic-content-parsing/GraphicContentInterpreter.h
@@ -126,7 +126,7 @@ private:
     bool EndTextElement();
 
     void RecordTextPlacement(const PlacedTextCommandArgument& inTextPlacementOperation);
-    void RecordTextPlacement(const PlacedTextCommandArgumentList& inTextPlacementOperations);
+    void RecordTextPlacement(const PlacedTextCommandArgumentVector& inTextPlacementOperations);
 
     bool PaintCurrentPath(bool inShouldStroke, bool inShouldFill, EFillMethod inFillMethod);
 };

--- a/TextExtraction/lib/graphic-content-parsing/TextElement.h
+++ b/TextExtraction/lib/graphic-content-parsing/TextElement.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <list>
+#include <vector>
 
 // PlacedTextCommandArgument matches an argument to a text placement command.
 // Mostly it'll be text, but for TJ it might be a text or a position
@@ -31,7 +32,7 @@ struct PlacedTextCommandArgument {
     double pos;
 };
 
-typedef std::list<PlacedTextCommandArgument> PlacedTextCommandArgumentList;
+typedef std::vector<PlacedTextCommandArgument> PlacedTextCommandArgumentVector;
 
 
 // PlacedTextCommand matches a text placement command like TJ, Tj etc.
@@ -39,7 +40,7 @@ typedef std::list<PlacedTextCommandArgument> PlacedTextCommandArgumentList;
 // text, but for TJ it might be an array of text of position
 // graphicState and textState are snapshots of the current graphic and text states
 struct PlacedTextCommand {
-    PlacedTextCommandArgumentList text;
+    PlacedTextCommandArgumentVector text;
     ContentGraphicState graphicState;
     TextGraphicState textState;
 };

--- a/TextExtraction/lib/interpreter/IPDFRecursiveInterpreterHandler.h
+++ b/TextExtraction/lib/interpreter/IPDFRecursiveInterpreterHandler.h
@@ -14,7 +14,6 @@ class PDFDictionary;
 class PDFObjectParser;
 
 typedef std::vector<PDFObject*> PDFObjectVector;
-typedef std::list<std::string> StringList;
 
 class IInterpreterContext {
     public:

--- a/TextExtraction/lib/text-parsing/TextInterpreter.cpp
+++ b/TextExtraction/lib/text-parsing/TextInterpreter.cpp
@@ -89,7 +89,7 @@ bool TextInterpeter::OnTextElementComplete(const TextElement& inTextElement) {
         double ascentPlacement = (decoder->ascent + item.textState.rise)*item.textState.fontSize/1000;
         double spaceWidth = (decoder->spaceWidth*item.textState.fontSize + item.textState.charSpace + item.textState.wordSpace)*item.textState.scale/100; 
 
-        PlacedTextCommandArgumentList::const_iterator argumentIt = item.text.begin();
+        PlacedTextCommandArgumentVector::const_iterator argumentIt = item.text.begin();
         for(;argumentIt != item.text.end() && shouldContinue;++argumentIt) {
             if(argumentIt->isText) {
                 // compute text argument


### PR DESCRIPTION
Changing PlacedTextCommandArgumentList to PlacedTextCommandArgumentVector gived 5% overall performance improvement.

Following https://github.com/galkahana/PDF-Writer/issues/322 is switched lists to vectors and repeatedly tested the performance of parsing 200 pages of the PDF reference manual. 
Comparing a complete replacement to just replacing PlacedTextCommandArgument list to vector i see that the performance gain is the same - easy 5% gain. So, switching just this, to get a gain that's focused and does not require further changes. 

i'm guessing other lists don't get created/modified as much. and we got that ByteList reasoning of adding/removing stuff is more efficient with vector then lists, especially around listed objects that are small.