### PR TITLE
conf: upgrade pdfwriter dep to v4.9.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,6 +18,21 @@
             "MIMode": "lldb"
         },
         {
+            "name": "(ctest-lldb) Launch",
+            "type": "cppdbg",
+            "request": "launch",
+            "presentation": {
+                "hidden": true
+            },
+            "program": "${cmake.testProgram}",
+            "args": [
+                "${cmake.testArgs}"
+            ],
+            "cwd": "${cmake.testWorkingDirectory}",
+            "externalConsole": false,
+            "MIMode": "lldb"
+        },
+        {
             "name": "(msvc) Launch",
             "type": "cppvsdbg",
             "request": "launch",
@@ -28,6 +43,20 @@
             "cwd": "${workspaceFolder}",
             "environment": [],
             "console": "integratedTerminal"
-        }        
+        },
+        {
+            "name": "(ctest-msvc) Launch",
+            "type": "cppvsdbg",
+            "request": "launch",
+            "presentation": {
+                "hidden": true
+            },
+            "program": "${cmake.testProgram}",
+            "args": [
+                "${cmake.testArgs}"
+            ],
+            "cwd": "${cmake.testWorkingDirectory}",
+            "console": "integratedTerminal"
+        }
     ]
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ option(SHOULD_PARSE_INTERNAL_TABLES  "should table parsing read internal tables"
 include(FetchContent)
 FetchContent_Declare(
   PDFHummus
-  URL https://github.com/galkahana/PDF-Writer/archive/refs/tags/v4.8.1.tar.gz
-  URL_HASH SHA256=9b96c040cb04ca116450c0ed53462b6aa66b299c555401bf498b14db847f0898
+  URL https://github.com/galkahana/PDF-Writer/archive/refs/tags/v4.9.0.tar.gz
+  URL_HASH SHA256=1d03fb6191bad40e8f2f218a2a2b7a8b6a679569f3f69bf6015ad82165feeb98
   DOWNLOAD_EXTRACT_TIMESTAMP FALSE
   FIND_PACKAGE_ARGS
 )

--- a/TextExtractionTesting/CMakeLists.txt
+++ b/TextExtractionTesting/CMakeLists.txt
@@ -36,7 +36,6 @@ set_property (TEST FuzzTest_output-output-dummy.txt-34544.pdf PROPERTY PASS_REGU
 set_property (TEST FuzzTest_radamsa-dummy-20507.pdf PROPERTY PASS_REGULAR_EXPRESSION "Error: Failed to parse file")
 set_property (TEST FuzzTest_radamsa-dummy-27773.pdf PROPERTY PASS_REGULAR_EXPRESSION "Error: Failed to parse file")
 set_property (TEST FuzzTest_radamsa-dummy-47574.pdf PROPERTY PASS_REGULAR_EXPRESSION "Error: Failed to parse file")
-set_property (TEST FuzzTest_radamsa-dummy-48570.pdf PROPERTY PASS_REGULAR_EXPRESSION "Error: Failed to parse file")
 set_property (TEST FuzzTest_radamsa-dummy-8532.pdf PROPERTY PASS_REGULAR_EXPRESSION "Error: Failed to parse file")
 
 # crash


### PR DESCRIPTION
upgrading pdfwriter dependency to v4.9.0.
pdfwriter went through a large vulnerabilities cleanup project, let's get those benefits